### PR TITLE
API Swagger validation fix

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -802,7 +802,7 @@
             "name": "id",
             "in": "path",
             "description": "The id of the profile to merge.",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer"
             }


### PR DESCRIPTION
# Description

OpenAPI schema validation failed.

ENUM must be equal to one of the allowed values
(query)

  4807 |           {
  4808 |             "name": "id",
> 4809 |             "in": "path",
       |                   ^^^^^^ 👈🏽  Did you mean query here?
  4810 |             "description": "The id of the profile to merge.",
  4811 |             "required": false,
  4812 |             "schema": {

Changed required to true 

# Tasks
  - [*] Added correct pull request label (work in progress, DO NOT MERGE, ready for review) etc


